### PR TITLE
changed dev channel pre-requisite to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This application is available under license from Oppkey, Inc.
 
 ## Pre-requisites
 
-* Flutter, master channel
+* Flutter, master channel - As of Nov 12, dev channel has bug - For now, we need to use the Flutter master channel - expect to use dev channel again eventually
 * Android SDK
 * Visual Studio
 * Android Studio
@@ -51,9 +51,10 @@ This application is available under license from Oppkey, Inc.
 $ flutter create .
 $ flutter pub get
 ```
-Make sure to use Flutter dev channel
+Make sure to use Flutter master channel (as of Nov 12) 
 ```
-$  flutter channel dev
+# CHANGE BACK TO DEV CHANNEL
+$  flutter channel master
 ```
 
 Make sure that you have the latest desktop support and that it’s enabled

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This application is available under license from Oppkey, Inc.
 
 ## Pre-requisites
 
-* Flutter, dev channel
+* Flutter, master channel
 * Android SDK
 * Visual Studio
 * Android Studio
@@ -121,9 +121,11 @@ In `AndroidManifest.xml`
 
 ### Sync Local Repo with Upstream (master repo)
 
-If the codetricity repo is ahead of jcasman, then fetch the upstream (codetricity) repo before you edit your code locally.
+If the codetricity repo is ahead of jcasman, then fetch the upstream (codetricity) repo before you edit your code locally and merge. Also, 
+a push is required to keep your fork up-to-date.
 
 ```
 git fetch upstream
 git merge upstream/main
+git push
 ```


### PR DESCRIPTION
Updating README to indicate that we are using the master channel for Flutter. Also, small detail, but under the Collaborative Work Process, updated the suggested steps: git fetch and merge, yes, but also do a git push from the local directory so the GitHub fork will be up-to-date.